### PR TITLE
[Matrix|N*] depends update, fixes, year increase and cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
   - if [[ $DEBIAN_BUILD != true ]]; then mkdir -p definition/${app_id}; fi
   - if [[ $DEBIAN_BUILD != true ]]; then echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt; fi
   - if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons; fi
-  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-addon-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep $TRAVIS_BUILD_DIR; fi
 
 script: 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This is a [Kodi](https://kodi.tv) audio decoder addon for GSF files.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.org/xbmc/audiodecoder.gsf.svg?branch=Matrix)](https://travis-ci.org/xbmc/audiodecoder.gsf/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.gsf?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=6&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.gsf/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.gsf/branches/)
 <!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.gsf?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-gsf?branch=Matrix) -->

--- a/audiodecoder.gsf/addon.xml.in
+++ b/audiodecoder.gsf/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.gsf"
-  version="3.0.0"
+  version="3.0.1"
   name="GSF Audio Decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,9 +1,9 @@
 Format: http://dep.debian.net/deps/dep5
 Upstream-Name: audiodecoder.gsf
-Source: <url://example.com>
+Source: https://github.com/xbmc/audiodecoder.gme
 
 Files: *
-Copyright: 2005-2020 Team Kodi
+Copyright: 2005-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/lib/kodi-psflib-note.txt
+++ b/lib/kodi-psflib-note.txt
@@ -1,2 +1,2 @@
 psflib source from https://github.com/kode54/psflib
-Sync to 38b1419 (28 Feb 2020)
+Sync to 77dfb4a (17 March 2021)

--- a/lib/kodi-viogsf-note.txt
+++ b/lib/kodi-viogsf-note.txt
@@ -1,2 +1,9 @@
-viogsf from https://github.com/kode54/viogsf
-Sync to f171786
+viogsf from https://git.lopez-snowhill.net/chris/viogsf
+Sync to 6c43a992 (30 January 2018)
+
+Include 2 own fixes about OS builds:
+- https://github.com/xbmc/audiodecoder.gsf/commit/cb3df9820214093b3d21f8b200eefe5be75ae09e
+- https://github.com/xbmc/audiodecoder.gsf/commit/2ce3b8b5cc38d67a1ee0b8755d53d1904d2babe9
+
+Old source:
+- https://github.com/kode54/viogsf

--- a/lib/psflib/psf2fs.c
+++ b/lib/psflib/psf2fs.c
@@ -414,7 +414,7 @@ static int virtual_read(struct PSF2FS *fs, struct DIR_ENTRY *entry, int offset, 
       destlen = block_usize;
       // attempt decompress
       r = uncompress((unsigned char *) fs->cacheblock.uncompressed_data, &destlen, (const unsigned char *) entry->source->reserved_data + block_zofs, block_zsize);
-      if(r != Z_OK || destlen != block_usize) {
+      if(r != Z_OK || destlen != (unsigned long)block_usize) {
 //        char s[999];
 //        sprintf(s,"zdata=%02X %02X %02X blockz=%d blocku=%d destlenout=%d", zdata[0], zdata[1], zdata[2], block_zsize, block_usize, destlen);
 //        errormessageadd(fs, s);

--- a/lib/viogsf/vbam/gba/Sound.cpp
+++ b/lib/viogsf/vbam/gba/Sound.cpp
@@ -428,7 +428,7 @@ static void remake_stereo_buffer(GBASystem *gba)
 void soundShutdown(GBASystem *gba)
 {
 	// APU
-    if ( !gba->gb_apu )
+    if (gba->gb_apu)
 	{
         delete gba->gb_apu;
         gba->gb_apu = 0;

--- a/src/GSFCodec.cpp
+++ b/src/GSFCodec.cpp
@@ -348,10 +348,10 @@ bool CGSFCodec::ReadTag(const std::string& filename, kodi::addon::AudioDecoderIn
     return false;
   }
 
-  if (!gsf.title.empty())
+  if (!gsf.artist.empty())
     tag.SetArtist(gsf.artist);
   else
-    tag.SetArtist(gsf.artist);
+    tag.SetArtist(gsf.game);
   tag.SetTitle(gsf.title);
   tag.SetAlbum(gsf.game);
   tag.SetReleaseDate(gsf.year);

--- a/src/GSFCodec.cpp
+++ b/src/GSFCodec.cpp
@@ -102,34 +102,30 @@ extern "C"
 
   static void* psf_file_fopen(void* context, const char* uri)
   {
-    fprintf(stderr, "-aaa------------< 1\n");
     kodi::vfs::CFile* file = new kodi::vfs::CFile;
     if (!file->OpenFile(uri, 0))
     {
       delete file;
       return nullptr;
     }
-fprintf(stderr, "-aaa------------< 1aa\n");
+
     return file;
   }
 
   static size_t psf_file_fread(void* buffer, size_t size, size_t count, void* handle)
   {
-    fprintf(stderr, "-aaa------------< 2\n");
     kodi::vfs::CFile* file = static_cast<kodi::vfs::CFile*>(handle);
     return file->Read(buffer, size * count);
   }
 
   static int psf_file_fseek(void* handle, int64_t offset, int whence)
   {
-    fprintf(stderr, "-aaa------------< 3\n");
     kodi::vfs::CFile* file = static_cast<kodi::vfs::CFile*>(handle);
     return file->Seek(offset, whence) > -1 ? 0 : -1;
   }
 
   static int psf_file_fclose(void* handle)
   {
-    fprintf(stderr, "-aaa------------< 4\n");
     delete static_cast<kodi::vfs::CFile*>(handle);
 
     return 0;
@@ -346,13 +342,12 @@ int64_t CGSFCodec::Seek(int64_t time)
 bool CGSFCodec::ReadTag(const std::string& filename, kodi::addon::AudioDecoderInfoTag& tag)
 {
   GSFContext gsf;
-fprintf(stderr, "-------------< 1\n");
   if (psf_load(filename.c_str(), &psf_file_system, 0x22, 0, 0, psf_info_meta, &gsf, 0, nullptr,
                nullptr) <= 0)
   {
     return false;
   }
-fprintf(stderr, "-------------< 2\n");
+
   if (!gsf.title.empty())
     tag.SetArtist(gsf.artist);
   else

--- a/src/GSFCodec.cpp
+++ b/src/GSFCodec.cpp
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2014-2020 Arne Morten Kvarving
- *  Copyright (C) 2016-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2014-2021 Arne Morten Kvarving
+ *  Copyright (C) 2016-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/GSFCodec.h
+++ b/src/GSFCodec.h
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2014-2020 Arne Morten Kvarving
- *  Copyright (C) 2016-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2014-2021 Arne Morten Kvarving
+ *  Copyright (C) 2016-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.


### PR DESCRIPTION
This update:
- psflib to latest version
- viogsf to latest version
- Remove the status badge about Travis CI
  - The build script stais currently in, maybe usable for something else or they allow again a bit more by travis.com
- Set copyright year to 2021
- Remove accidentally added string output from a debug before
- Fix artist fallback set to game name

Performed compile and run test on Linux with C++14, C++17 and C++20.
Runtime tests was OK.